### PR TITLE
feat: issue temporary password using mail

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,9 @@ jobs:
       DEV_AWS_ACCESS_KEY: ${{ secrets.DEV_AWS_ACCESS_KEY }}
       DEV_AWS_SECRET_KEY: ${{ secrets.DEV_AWS_SECRET_KEY }}
       DEV_AWS_S3_BUCKET_NAME: ${{ secrets.DEV_AWS_S3_BUCKET_NAME }}
+      MAIL_HOST: ${{ secrets.MAIL_HOST }}
+      MAIL_EMAIL: ${{ secrets.MAIL_EMAIL }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,6 +14,9 @@ jobs:
       DEV_AWS_ACCESS_KEY: ${{ secrets.DEV_AWS_ACCESS_KEY }}
       DEV_AWS_SECRET_KEY: ${{ secrets.DEV_AWS_SECRET_KEY }}
       DEV_AWS_S3_BUCKET_NAME: ${{ secrets.DEV_AWS_S3_BUCKET_NAME }}
+      MAIL_HOST: ${{ secrets.MAIL_HOST }}
+      MAIL_EMAIL: ${{ secrets.MAIL_EMAIL }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,14 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-aws</artifactId>
             <version>2.2.6.RELEASE</version>

--- a/src/main/java/com/depromeet/archive/api/dto/user/BaseUserDto.java
+++ b/src/main/java/com/depromeet/archive/api/dto/user/BaseUserDto.java
@@ -1,6 +1,7 @@
 package com.depromeet.archive.api.dto.user;
 
 import com.depromeet.archive.domain.user.entity.BaseUser;
+import com.depromeet.archive.util.DateTimeUtil;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,6 +17,10 @@ public class BaseUserDto {
 
     public static BaseUserDto from(BaseUser baseUser) {
         return new BaseUserDto(baseUser.getUserId(), baseUser.getMailAddress(), baseUser.getCreatedAt());
+    }
+
+    public String getCreatedAt() {
+        return DateTimeUtil.DATE_TIME_FORMATTER.format(this.createdAt);
     }
 
 }

--- a/src/main/java/com/depromeet/archive/api/dto/user/BaseUserDto.java
+++ b/src/main/java/com/depromeet/archive/api/dto/user/BaseUserDto.java
@@ -1,12 +1,10 @@
 package com.depromeet.archive.api.dto.user;
 
 import com.depromeet.archive.domain.user.entity.BaseUser;
-import com.depromeet.archive.util.DateTimeUtil;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @RequiredArgsConstructor
 @Getter
@@ -20,7 +18,4 @@ public class BaseUserDto {
         return new BaseUserDto(baseUser.getUserId(), baseUser.getMailAddress(), baseUser.getCreatedAt());
     }
 
-    public String getCreatedAt() {
-        return DateTimeUtil.DATE_TIME_FORMATTER.format(createdAt);
-    }
 }

--- a/src/main/java/com/depromeet/archive/api/dto/user/UserEmailDto.java
+++ b/src/main/java/com/depromeet/archive/api/dto/user/UserEmailDto.java
@@ -1,0 +1,17 @@
+package com.depromeet.archive.api.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserEmailDto {
+
+    @Email
+    private String email;
+
+}

--- a/src/main/java/com/depromeet/archive/api/user/RegisterController.java
+++ b/src/main/java/com/depromeet/archive/api/user/RegisterController.java
@@ -1,7 +1,6 @@
 package com.depromeet.archive.api.user;
 
 import com.depromeet.archive.api.dto.user.OAuthRegisterDto;
-import com.depromeet.archive.domain.common.MessagingService;
 import com.depromeet.archive.domain.user.UserService;
 import com.depromeet.archive.domain.user.command.PasswordRegisterCommand;
 import com.depromeet.archive.domain.user.info.UserInfo;
@@ -28,7 +27,6 @@ public class RegisterController {
 
     private final UserService userService;
     private final OAuthUserService oAuthUserService;
-    private final MessagingService messagingService;
     private final PasswordEncoder encoder;
 
     // JWT token provider
@@ -38,8 +36,7 @@ public class RegisterController {
     @PostMapping("/register")
     public ResponseEntity<Void> registerUser(@RequestBody @Valid PasswordRegisterCommand command) {
         encryptPassword(command);
-        var baseUserDto = userService.registerUser(command);
-        messagingService.sendUserRegisterMessage(baseUserDto);
+        userService.registerUser(command);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/depromeet/archive/api/user/RegisterController.java
+++ b/src/main/java/com/depromeet/archive/api/user/RegisterController.java
@@ -1,7 +1,7 @@
 package com.depromeet.archive.api.user;
 
 import com.depromeet.archive.api.dto.user.OAuthRegisterDto;
-import com.depromeet.archive.domain.user.UserService;
+import com.depromeet.archive.domain.user.UserRegisterService;
 import com.depromeet.archive.domain.user.command.PasswordRegisterCommand;
 import com.depromeet.archive.domain.user.info.UserInfo;
 import com.depromeet.archive.infra.user.oauth.OAuthUserService;
@@ -25,7 +25,7 @@ import javax.validation.Valid;
 @RequiredArgsConstructor
 public class RegisterController {
 
-    private final UserService userService;
+    private final UserRegisterService userRegisterService;
     private final OAuthUserService oAuthUserService;
     private final PasswordEncoder encoder;
 
@@ -36,7 +36,7 @@ public class RegisterController {
     @PostMapping("/register")
     public ResponseEntity<Void> registerUser(@RequestBody @Valid PasswordRegisterCommand command) {
         encryptPassword(command);
-        userService.registerUser(command);
+        userRegisterService.registerUser(command);
         return ResponseEntity.ok().build();
     }
 
@@ -45,7 +45,7 @@ public class RegisterController {
                                                           @RequestParam("provider") String provider,
                                                           @RequestBody(required = false) OAuthRegisterDto oAuthRegisterDto) {
         var oAuthRegisterInfo = oAuthUserService.getOAuthRegisterInfo(provider, oAuthRegisterDto);
-        var userInfo = userService.getOrRegisterUserReturnInfo(oAuthRegisterInfo);
+        var userInfo = userRegisterService.getOrRegisterUserReturnInfo(oAuthRegisterInfo);
         injectJwtToken(httpServletResponse, userInfo);
         return ResponseEntity.ok().build();
 

--- a/src/main/java/com/depromeet/archive/api/user/UserController.java
+++ b/src/main/java/com/depromeet/archive/api/user/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
     @Operation(summary = "이메일 중복 검사")
     @GetMapping("/email/{email}")
     public ResponseEntity<EmailDuplicateResponseDto> checkDuplicatedEmail(@PathVariable String email) {
-        var emailDuplicateResponseDto = new EmailDuplicateResponseDto(userService.isDuplicatedEmail(email));
+        var emailDuplicateResponseDto = new EmailDuplicateResponseDto(userService.existsEmail(email));
         return ResponseEntity.ok(emailDuplicateResponseDto);
     }
 

--- a/src/main/java/com/depromeet/archive/api/user/UserController.java
+++ b/src/main/java/com/depromeet/archive/api/user/UserController.java
@@ -1,20 +1,28 @@
 package com.depromeet.archive.api.user;
 
 import com.depromeet.archive.api.dto.archive.EmailDuplicateResponseDto;
+import com.depromeet.archive.api.dto.user.UserEmailDto;
 import com.depromeet.archive.api.resolver.annotation.RequestUser;
 import com.depromeet.archive.domain.user.UserService;
 import com.depromeet.archive.domain.user.info.UserInfo;
+import com.depromeet.archive.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class UserController {
 
+    private static final int TEMP_PASSWORD_LENGTH = 10;
     private final UserService userService;
 
     @DeleteMapping("/unregister")
@@ -33,6 +41,14 @@ public class UserController {
     public ResponseEntity<EmailDuplicateResponseDto> checkDuplicatedEmail(@PathVariable String email) {
         var emailDuplicateResponseDto = new EmailDuplicateResponseDto(userService.existsEmail(email));
         return ResponseEntity.ok(emailDuplicateResponseDto);
+    }
+
+    @Operation(summary = "비밀번호 초기화 - 임시 비밀번호 발급")
+    @PostMapping("/password")
+    public ResponseEntity<Void> resetPassword(@RequestBody UserEmailDto userEmailDto) {
+        var temporaryPassword = SecurityUtils.generateRandomString(TEMP_PASSWORD_LENGTH);
+        userService.updateTemporaryPassword(userEmailDto.getEmail(), temporaryPassword);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/depromeet/archive/config/AsyncConfiguration.java
+++ b/src/main/java/com/depromeet/archive/config/AsyncConfiguration.java
@@ -1,0 +1,66 @@
+package com.depromeet.archive.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableConfigurationProperties(AsyncConfiguration.MailExecutorProperty.class)
+@EnableAsync
+@RequiredArgsConstructor
+@Slf4j
+public class AsyncConfiguration implements AsyncConfigurer {
+
+    private final MailExecutorProperty mailExecutorProperty;
+
+    @Override
+    @Bean("mailExecutor")
+    public Executor getAsyncExecutor() {
+        var executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(mailExecutorProperty.getCorePoolSize());
+        executor.setMaxPoolSize(mailExecutorProperty.getMaxPoolSize());
+        executor.setQueueCapacity(mailExecutorProperty.getQueueCapacity());
+        executor.setAwaitTerminationSeconds(mailExecutorProperty.getAwaitTerminationSeconds());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setThreadNamePrefix(MailExecutorProperty.THREAD_NAME_PREFIX);
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (exception, method, params) ->
+                log.error("Async Exception handler: '{}' threw unexpected exception ",
+                        method.toGenericString(), exception);
+    }
+
+    @ConfigurationProperties(prefix = "spring.mail.executor")
+    @ConstructorBinding
+    @AllArgsConstructor
+    @Getter
+    @ToString
+    public static class MailExecutorProperty {
+
+        private static final String THREAD_NAME_PREFIX = "mail-executor-";
+
+        private int corePoolSize;
+        private int maxPoolSize;
+        private int queueCapacity;
+        private int awaitTerminationSeconds;
+
+    }
+
+}

--- a/src/main/java/com/depromeet/archive/config/AuthConfig.java
+++ b/src/main/java/com/depromeet/archive/config/AuthConfig.java
@@ -2,14 +2,14 @@ package com.depromeet.archive.config;
 
 import com.depromeet.archive.domain.archive.ArchiveRepository;
 import com.depromeet.archive.domain.user.UserLoginService;
-import com.depromeet.archive.domain.user.UserService;
+import com.depromeet.archive.domain.user.UserRegisterService;
 import com.depromeet.archive.security.authorization.permissionhandler.ArchiveAdminOrAuthorChecker;
 import com.depromeet.archive.security.general.UserNamePasswordAuthenticationProvider;
+import com.depromeet.archive.security.oauth.OAuthUserService;
 import com.depromeet.archive.security.result.LoginFailureHandler;
 import com.depromeet.archive.security.result.LoginSuccessHandler;
 import com.depromeet.archive.security.token.HttpAuthTokenSupport;
 import com.depromeet.archive.security.token.TokenProvider;
-import com.depromeet.archive.security.oauth.OAuthUserService;
 import com.depromeet.archive.security.token.jwt.JwtTokenProvider;
 import com.depromeet.archive.security.token.jwt.JwtTokenSupport;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,9 +32,8 @@ public class AuthConfig {
     }
 
     @Bean
-    public OAuthUserService oAuthUserService(UserService userService) {
-        OAuthUserService oAuthUserService = new OAuthUserService(userService);
-        return oAuthUserService;
+    public OAuthUserService oAuthUserService(UserRegisterService userRegisterService) {
+        return new OAuthUserService(userRegisterService);
     }
 
     @Bean
@@ -53,7 +52,9 @@ public class AuthConfig {
     }
 
     @Bean
-    public LoginFailureHandler failureHandler() {return new LoginFailureHandler(); }
+    public LoginFailureHandler failureHandler() {
+        return new LoginFailureHandler();
+    }
 
     @Bean
     public PasswordEncoder encoder() {

--- a/src/main/java/com/depromeet/archive/domain/common/MessagingService.java
+++ b/src/main/java/com/depromeet/archive/domain/common/MessagingService.java
@@ -1,9 +1,9 @@
 package com.depromeet.archive.domain.common;
 
-import com.depromeet.archive.api.dto.user.BaseUserDto;
+import com.depromeet.archive.domain.user.entity.BaseUser;
 
 public interface MessagingService {
 
-    void sendUserRegisterMessage(BaseUserDto baseUserDto);
+    void sendUserRegisterMessage(BaseUser baseUser, String registerType);
 
 }

--- a/src/main/java/com/depromeet/archive/domain/common/MessagingService.java
+++ b/src/main/java/com/depromeet/archive/domain/common/MessagingService.java
@@ -1,9 +1,9 @@
 package com.depromeet.archive.domain.common;
 
-import com.depromeet.archive.domain.user.entity.BaseUser;
+import com.depromeet.archive.api.dto.user.BaseUserDto;
 
 public interface MessagingService {
 
-    void sendUserRegisterMessage(BaseUser baseUser, String registerType);
+    void sendUserRegisterMessage(BaseUserDto user, String registerType);
 
 }

--- a/src/main/java/com/depromeet/archive/domain/user/UserLoginService.java
+++ b/src/main/java/com/depromeet/archive/domain/user/UserLoginService.java
@@ -1,15 +1,17 @@
 package com.depromeet.archive.domain.user;
 
 import com.depromeet.archive.domain.user.command.LoginCommand;
-import com.depromeet.archive.domain.user.entity.PasswordUser;
 import com.depromeet.archive.domain.user.info.UserInfo;
+import com.depromeet.archive.exception.common.ResourceNotFoundException;
 import com.depromeet.archive.exception.user.LoginFailException;
 import com.depromeet.archive.infra.user.jpa.PasswordUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserLoginService {
 
@@ -17,9 +19,9 @@ public class UserLoginService {
     private final PasswordEncoder encoder;
 
     public UserInfo tryLoginAndReturnInfo(LoginCommand command) throws LoginFailException {
-        PasswordUser user = repository.findPasswordUserByMailAddress(command.getEmail());
-        String encryptedPassword = user.getPassword();
-        if (!encoder.matches(command.getPassword(), encryptedPassword))
+        var user = repository.findPasswordUserByMailAddress(command.getEmail())
+                .orElseThrow(() -> new ResourceNotFoundException("Email"));
+        if (!encoder.matches(command.getPassword(), user.getPassword()))
             throw new LoginFailException("로그인에 실패하였습니다. 비밀번호가 다릅니다.");
         return user.convertToUserInfo();
     }

--- a/src/main/java/com/depromeet/archive/domain/user/UserRegisterService.java
+++ b/src/main/java/com/depromeet/archive/domain/user/UserRegisterService.java
@@ -1,0 +1,58 @@
+package com.depromeet.archive.domain.user;
+
+import com.depromeet.archive.api.dto.user.BaseUserDto;
+import com.depromeet.archive.domain.common.MessagingService;
+import com.depromeet.archive.domain.user.command.BasicRegisterCommand;
+import com.depromeet.archive.domain.user.command.OAuthRegisterCommand;
+import com.depromeet.archive.domain.user.entity.BaseUser;
+import com.depromeet.archive.domain.user.info.UserInfo;
+import com.depromeet.archive.exception.common.DuplicateResourceException;
+import com.depromeet.archive.infra.user.jpa.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@Slf4j
+@RequiredArgsConstructor
+public class UserRegisterService {
+
+    private final UserRepository userRepository;
+    private final MessagingService messagingService;
+
+    public long getOrRegisterUser(BasicRegisterCommand registerCommand) {
+        var user = userRepository.findByMailAddress(registerCommand.getEmail())
+                .orElseGet(() -> registerUser(registerCommand));
+        return user.getUserId();
+    }
+
+    public UserInfo getOrRegisterUserReturnInfo(BasicRegisterCommand registerCommand) {
+        var user = userRepository.findByMailAddress(registerCommand.getEmail())
+                .orElseGet(() -> registerUser(registerCommand));
+        return user.convertToUserInfo();
+    }
+
+    public BaseUser registerUser(BasicRegisterCommand registerCommand) {
+        try {
+            var user = userRepository.save(registerCommand.toUserEntity());
+            sendRegisterNotification(registerCommand, user);
+            return user;
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateResourceException("이메일이 이미 존재합니다.");
+        }
+    }
+
+    private void sendRegisterNotification(BasicRegisterCommand registerCommand, BaseUser user) {
+        if (registerCommand instanceof OAuthRegisterCommand) {
+            var oAuthRegisterCommand = (OAuthRegisterCommand) registerCommand;
+            var oauthProvider = oAuthRegisterCommand.getProvider().getRegistrationId();
+            messagingService.sendUserRegisterMessage(BaseUserDto.from(user), oauthProvider);
+        } else {
+            messagingService.sendUserRegisterMessage(BaseUserDto.from(user), "Id/Password");
+        }
+    }
+
+}

--- a/src/main/java/com/depromeet/archive/domain/user/UserService.java
+++ b/src/main/java/com/depromeet/archive/domain/user/UserService.java
@@ -5,12 +5,17 @@ import com.depromeet.archive.domain.common.MessagingService;
 import com.depromeet.archive.domain.user.command.BasicRegisterCommand;
 import com.depromeet.archive.domain.user.command.OAuthRegisterCommand;
 import com.depromeet.archive.domain.user.entity.BaseUser;
+import com.depromeet.archive.domain.user.entity.PasswordUser;
 import com.depromeet.archive.domain.user.info.UserInfo;
 import com.depromeet.archive.exception.common.DuplicateResourceException;
+import com.depromeet.archive.exception.common.ResourceNotFoundException;
+import com.depromeet.archive.exception.user.OAuthUserHasNotPasswordException;
+import com.depromeet.archive.infra.mail.MailService;
 import com.depromeet.archive.infra.user.jpa.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +27,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final MessagingService messagingService;
+    private final PasswordEncoder encoder;
+    private final MailService mailService;
 
     public boolean existsEmail(String email) {
         return userRepository.findByMailAddress(email).isPresent();
@@ -49,6 +56,14 @@ public class UserService {
         }
     }
 
+    public void updateTemporaryPassword(final String email, final String temporaryPassword) {
+        var passwordUser = userRepository.findByMailAddress(email)
+                .map(this::convertPasswordUser)
+                .orElseThrow(() -> new ResourceNotFoundException("Email"));
+        passwordUser.setTemporaryPassword(encoder.encode(temporaryPassword));
+        mailService.sendTemporaryPassword(email, temporaryPassword);
+    }
+
     public void deleteUser(long userId) {
         BaseUser user = userRepository.getById(userId);
         userRepository.delete(user);
@@ -62,6 +77,13 @@ public class UserService {
         } else {
             messagingService.sendUserRegisterMessage(BaseUserDto.from(user), "Id/Password");
         }
+    }
+
+    private PasswordUser convertPasswordUser(BaseUser user) {
+        if (!(user instanceof PasswordUser)) {
+            throw new OAuthUserHasNotPasswordException();
+        }
+        return (PasswordUser) user;
     }
 
 }

--- a/src/main/java/com/depromeet/archive/domain/user/UserService.java
+++ b/src/main/java/com/depromeet/archive/domain/user/UserService.java
@@ -23,7 +23,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final MessagingService messagingService;
 
-    public boolean isDuplicatedEmail(String email) {
+    public boolean existsEmail(String email) {
         return userRepository.findByMailAddress(email).isPresent();
     }
 

--- a/src/main/java/com/depromeet/archive/domain/user/UserService.java
+++ b/src/main/java/com/depromeet/archive/domain/user/UserService.java
@@ -1,20 +1,13 @@
 package com.depromeet.archive.domain.user;
 
-import com.depromeet.archive.api.dto.user.BaseUserDto;
-import com.depromeet.archive.domain.common.MessagingService;
-import com.depromeet.archive.domain.user.command.BasicRegisterCommand;
-import com.depromeet.archive.domain.user.command.OAuthRegisterCommand;
 import com.depromeet.archive.domain.user.entity.BaseUser;
 import com.depromeet.archive.domain.user.entity.PasswordUser;
-import com.depromeet.archive.domain.user.info.UserInfo;
-import com.depromeet.archive.exception.common.DuplicateResourceException;
 import com.depromeet.archive.exception.common.ResourceNotFoundException;
 import com.depromeet.archive.exception.user.OAuthUserHasNotPasswordException;
 import com.depromeet.archive.infra.mail.MailService;
 import com.depromeet.archive.infra.user.jpa.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,34 +19,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final MessagingService messagingService;
     private final PasswordEncoder encoder;
     private final MailService mailService;
 
     public boolean existsEmail(String email) {
         return userRepository.findByMailAddress(email).isPresent();
-    }
-
-    public long getOrRegisterUser(BasicRegisterCommand registerCommand) {
-        var user = userRepository.findByMailAddress(registerCommand.getEmail())
-                .orElseGet(() -> registerUser(registerCommand));
-        return user.getUserId();
-    }
-
-    public UserInfo getOrRegisterUserReturnInfo(BasicRegisterCommand registerCommand) {
-        var user = userRepository.findByMailAddress(registerCommand.getEmail())
-                .orElseGet(() -> registerUser(registerCommand));
-        return user.convertToUserInfo();
-    }
-
-    public BaseUser registerUser(BasicRegisterCommand registerCommand) {
-        try {
-            var user = userRepository.save(registerCommand.toUserEntity());
-            sendRegisterNotification(registerCommand, user);
-            return user;
-        } catch (DataIntegrityViolationException e) {
-            throw new DuplicateResourceException("이메일이 이미 존재합니다.");
-        }
     }
 
     public void updateTemporaryPassword(final String email, final String temporaryPassword) {
@@ -67,16 +37,6 @@ public class UserService {
     public void deleteUser(long userId) {
         BaseUser user = userRepository.getById(userId);
         userRepository.delete(user);
-    }
-
-    private void sendRegisterNotification(BasicRegisterCommand registerCommand, BaseUser user) {
-        if (registerCommand instanceof OAuthRegisterCommand) {
-            var oAuthRegisterCommand = (OAuthRegisterCommand) registerCommand;
-            var oauthProvider = oAuthRegisterCommand.getProvider().getRegistrationId();
-            messagingService.sendUserRegisterMessage(BaseUserDto.from(user), oauthProvider);
-        } else {
-            messagingService.sendUserRegisterMessage(BaseUserDto.from(user), "Id/Password");
-        }
     }
 
     private PasswordUser convertPasswordUser(BaseUser user) {

--- a/src/main/java/com/depromeet/archive/domain/user/command/OAuthRegisterCommand.java
+++ b/src/main/java/com/depromeet/archive/domain/user/command/OAuthRegisterCommand.java
@@ -4,9 +4,11 @@ import com.depromeet.archive.domain.user.entity.BaseUser;
 import com.depromeet.archive.domain.user.entity.OAuthProvider;
 import com.depromeet.archive.domain.user.entity.OAuthUser;
 import com.depromeet.archive.domain.user.entity.UserRole;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
+@Getter
 public class OAuthRegisterCommand extends BasicRegisterCommand {
 
     private OAuthProvider provider;

--- a/src/main/java/com/depromeet/archive/domain/user/entity/PasswordUser.java
+++ b/src/main/java/com/depromeet/archive/domain/user/entity/PasswordUser.java
@@ -22,4 +22,9 @@ public class PasswordUser extends BaseUser {
         super(mailAddress, role);
         this.password = password;
     }
+
+    public void setTemporaryPassword(final String temporaryPassword) {
+        this.password = temporaryPassword;
+    }
+
 }

--- a/src/main/java/com/depromeet/archive/exception/ExceptionCode.java
+++ b/src/main/java/com/depromeet/archive/exception/ExceptionCode.java
@@ -20,7 +20,7 @@ public enum ExceptionCode {
 
     // Common
     DUPLICATED_RESOURCE(HttpStatus.CONFLICT, "Common001", "이미 존재하는 리소스 입니다"),
-    NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, "Common002", "존재 하지 않는 리소스 입니다"),
+    NOT_FOUND_RESOURCE(HttpStatus.BAD_REQUEST, "Common002", "존재 하지 않는 리소스 입니다"),
 
     // User
     LOGIN_FAIL(HttpStatus.BAD_REQUEST, "User001", "로그인에 실패했습니다"),

--- a/src/main/java/com/depromeet/archive/exception/ExceptionCode.java
+++ b/src/main/java/com/depromeet/archive/exception/ExceptionCode.java
@@ -25,7 +25,7 @@ public enum ExceptionCode {
     // User
     LOGIN_FAIL(HttpStatus.BAD_REQUEST, "User001", "로그인에 실패했습니다"),
     REGISTER_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "User002", "회원가입에 실패했습니다"),
-    OAUTH_USER_NOT_HAS_PASSWORD(HttpStatus.BAD_REQUEST, "User003", "소셜 로그인 회원은 비밀번호 찾기를 할 수 없습니다"),
+    OAUTH_USER_NOT_HAS_PASSWORD(HttpStatus.FORBIDDEN, "User003", "소셜 로그인 회원은 비밀번호 찾기를 할 수 없습니다"),
 
     // Security
     TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "Security001", "`Authorization` 헤더에 토큰이 존재하지 않습니다"),

--- a/src/main/java/com/depromeet/archive/exception/ExceptionCode.java
+++ b/src/main/java/com/depromeet/archive/exception/ExceptionCode.java
@@ -25,6 +25,7 @@ public enum ExceptionCode {
     // User
     LOGIN_FAIL(HttpStatus.BAD_REQUEST, "User001", "로그인에 실패했습니다"),
     REGISTER_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "User002", "회원가입에 실패했습니다"),
+    OAUTH_USER_NOT_HAS_PASSWORD(HttpStatus.BAD_REQUEST, "User003", "소셜 로그인 회원은 비밀번호 찾기를 할 수 없습니다"),
 
     // Security
     TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "Security001", "`Authorization` 헤더에 토큰이 존재하지 않습니다"),

--- a/src/main/java/com/depromeet/archive/exception/user/OAuthUserHasNotPasswordException.java
+++ b/src/main/java/com/depromeet/archive/exception/user/OAuthUserHasNotPasswordException.java
@@ -1,0 +1,12 @@
+package com.depromeet.archive.exception.user;
+
+import com.depromeet.archive.exception.BaseException;
+import com.depromeet.archive.exception.ExceptionCode;
+
+public class OAuthUserHasNotPasswordException extends BaseException {
+
+    public OAuthUserHasNotPasswordException() {
+        super(ExceptionCode.OAUTH_USER_NOT_HAS_PASSWORD);
+    }
+
+}

--- a/src/main/java/com/depromeet/archive/infra/mail/MailService.java
+++ b/src/main/java/com/depromeet/archive/infra/mail/MailService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring5.SpringTemplateEngine;
@@ -26,6 +27,7 @@ public class MailService {
     @Value("${spring.mail.username}")
     private String fromEmail;
 
+    @Async("mailExecutor")
     public void sendTemporaryPassword(final String targetEmail, final String temporaryPassword) {
         var context = new Context(null, Map.of("password", temporaryPassword));
         var body = templateEngine.process(TEMPORARY_PASSWORD_MAIL.templateName, context);

--- a/src/main/java/com/depromeet/archive/infra/mail/MailService.java
+++ b/src/main/java/com/depromeet/archive/infra/mail/MailService.java
@@ -50,7 +50,7 @@ public class MailService {
 
     @Getter
     public enum MailTemplate {
-        TEMPORARY_PASSWORD_MAIL("[Archive] 임시 비밀번호 발급 안내", "temporary-password-mail-template");
+        TEMPORARY_PASSWORD_MAIL("[Archive] 고객님께서 요청하신 Archive 앱의 임시 비밀번호입니다.", "temporary-password-mail-template");
 
         private final String subject;
         private final String templateName;

--- a/src/main/java/com/depromeet/archive/infra/mail/MailService.java
+++ b/src/main/java/com/depromeet/archive/infra/mail/MailService.java
@@ -1,0 +1,65 @@
+package com.depromeet.archive.infra.mail;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.util.Map;
+
+import static com.depromeet.archive.infra.mail.MailService.MailTemplate.TEMPORARY_PASSWORD_MAIL;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    public void sendTemporaryPassword(final String targetEmail, final String temporaryPassword) {
+        var context = new Context(null, Map.of("password", temporaryPassword));
+        var body = templateEngine.process(TEMPORARY_PASSWORD_MAIL.templateName, context);
+        sendMail(targetEmail, TEMPORARY_PASSWORD_MAIL.subject, body);
+    }
+
+    private void sendMail(final String targetEmail, final String subject, final String body) {
+        MimeMessagePreparator messagePreparator = mimeMessage -> messageHelper(targetEmail, subject, body, mimeMessage);
+        mailSender.send(messagePreparator);
+    }
+
+    private void messageHelper(final String targetEmail,
+                               final String subject,
+                               final String body,
+                               MimeMessage mimeMessage) throws MessagingException {
+        final var helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+        helper.setFrom(fromEmail);
+        helper.setTo(targetEmail);
+        helper.setSubject(subject);
+        helper.setText(body, true);
+    }
+
+    @Getter
+    public enum MailTemplate {
+        TEMPORARY_PASSWORD_MAIL("[Archive] 임시 비밀번호 발급 안내", "temporary-password-mail-template");
+
+        private final String subject;
+        private final String templateName;
+
+        MailTemplate(String subject, String templateName) {
+            this.subject = subject;
+            this.templateName = templateName;
+        }
+
+    }
+
+}

--- a/src/main/java/com/depromeet/archive/infra/messaging/SlackService.java
+++ b/src/main/java/com/depromeet/archive/infra/messaging/SlackService.java
@@ -1,12 +1,14 @@
 package com.depromeet.archive.infra.messaging;
 
-import com.depromeet.archive.api.dto.user.BaseUserDto;
 import com.depromeet.archive.domain.common.MessagingService;
+import com.depromeet.archive.domain.user.entity.BaseUser;
 import com.depromeet.archive.exception.infra.SlackException;
 import com.depromeet.archive.infra.messaging.config.SlackProperty;
+import com.depromeet.archive.util.DateTimeUtil;
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -22,13 +24,16 @@ public class SlackService implements MessagingService {
     private final SlackProperty slackProperty;
     private final MethodsClient slackClient;
 
+    @Value("${spring.profiles.active}")
+    private String profile;
+
     public SlackService(final SlackProperty slackProperty) {
         this.slackProperty = slackProperty;
         this.slackClient = Slack.getInstance().methods(slackProperty.getToken());
     }
 
     @Override
-    public void sendUserRegisterMessage(final BaseUserDto baseUserDto) {
+    public void sendUserRegisterMessage(final BaseUser baseUser, final String registerType) {
         try {
             slackClient.chatPostMessage(req -> req
                     .channel(slackProperty.getChannel())
@@ -36,9 +41,12 @@ public class SlackService implements MessagingService {
                             divider(),
                             section(section -> section.text(markdownText(":tada: *새로운 유저가 찾아왔어요* :tada:"))),
                             divider(),
-                            section(section -> section.text(markdownText(String.format(":man-raising-hand::skin-tone-2: `유저 인덱스`: %s", baseUserDto.getUserId())))),
-                            section(section -> section.text(markdownText(String.format(":email: `이메일`: %s", baseUserDto.getMailAddress())))),
-                            section(section -> section.text(markdownText(String.format(":date: `가입시간`: %s", baseUserDto.getCreatedAt()))))
+                            section(section -> section.text(markdownText(String.format(":factory: `환경`: %s", profile)))),
+                            divider(),
+                            section(section -> section.text(markdownText(String.format(":sparkles: `회원가입 타입`: %s", registerType)))),
+                            section(section -> section.text(markdownText(String.format(":man-raising-hand::skin-tone-2: `유저 인덱스`: %s", baseUser.getUserId())))),
+                            section(section -> section.text(markdownText(String.format(":email: `이메일`: %s", baseUser.getMailAddress())))),
+                            section(section -> section.text(markdownText(String.format(":date: `가입시간`: %s", DateTimeUtil.DATE_TIME_FORMATTER.format(baseUser.getCreatedAt())))))
                     )));
         } catch (IOException | SlackApiException e) {
             throw new SlackException(e.getMessage());

--- a/src/main/java/com/depromeet/archive/infra/messaging/SlackService.java
+++ b/src/main/java/com/depromeet/archive/infra/messaging/SlackService.java
@@ -1,10 +1,9 @@
 package com.depromeet.archive.infra.messaging;
 
+import com.depromeet.archive.api.dto.user.BaseUserDto;
 import com.depromeet.archive.domain.common.MessagingService;
-import com.depromeet.archive.domain.user.entity.BaseUser;
 import com.depromeet.archive.exception.infra.SlackException;
 import com.depromeet.archive.infra.messaging.config.SlackProperty;
-import com.depromeet.archive.util.DateTimeUtil;
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
@@ -33,7 +32,7 @@ public class SlackService implements MessagingService {
     }
 
     @Override
-    public void sendUserRegisterMessage(final BaseUser baseUser, final String registerType) {
+    public void sendUserRegisterMessage(final BaseUserDto baseUser, final String registerType) {
         try {
             slackClient.chatPostMessage(req -> req
                     .channel(slackProperty.getChannel())
@@ -46,7 +45,7 @@ public class SlackService implements MessagingService {
                             section(section -> section.text(markdownText(String.format(":sparkles: `회원가입 타입`: %s", registerType)))),
                             section(section -> section.text(markdownText(String.format(":man-raising-hand::skin-tone-2: `유저 인덱스`: %s", baseUser.getUserId())))),
                             section(section -> section.text(markdownText(String.format(":email: `이메일`: %s", baseUser.getMailAddress())))),
-                            section(section -> section.text(markdownText(String.format(":date: `가입시간`: %s", DateTimeUtil.DATE_TIME_FORMATTER.format(baseUser.getCreatedAt())))))
+                            section(section -> section.text(markdownText(String.format(":date: `가입시간`: %s", baseUser.getCreatedAt()))))
                     )));
         } catch (IOException | SlackApiException e) {
             throw new SlackException(e.getMessage());

--- a/src/main/java/com/depromeet/archive/infra/user/jpa/PasswordUserRepository.java
+++ b/src/main/java/com/depromeet/archive/infra/user/jpa/PasswordUserRepository.java
@@ -2,9 +2,9 @@ package com.depromeet.archive.infra.user.jpa;
 
 import com.depromeet.archive.domain.user.entity.PasswordUser;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
+import java.util.Optional;
+
 public interface PasswordUserRepository extends JpaRepository<PasswordUser, Long> {
-    PasswordUser findPasswordUserByMailAddress(String mailAddress);
+    Optional<PasswordUser> findPasswordUserByMailAddress(String mailAddress);
 }

--- a/src/main/java/com/depromeet/archive/security/oauth/OAuthUserService.java
+++ b/src/main/java/com/depromeet/archive/security/oauth/OAuthUserService.java
@@ -1,6 +1,6 @@
 package com.depromeet.archive.security.oauth;
 
-import com.depromeet.archive.domain.user.UserService;
+import com.depromeet.archive.domain.user.UserRegisterService;
 import com.depromeet.archive.domain.user.command.OAuthRegisterCommand;
 import com.depromeet.archive.domain.user.entity.OAuthProvider;
 import com.depromeet.archive.security.common.UserPrincipal;
@@ -11,10 +11,10 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 
 public class OAuthUserService extends DefaultOAuth2UserService {
 
-    private final UserService userService;
+    private final UserRegisterService userRegisterService;
 
-    public OAuthUserService(UserService service) {
-        this.userService = service;
+    public OAuthUserService(UserRegisterService userRegisterService) {
+        this.userRegisterService = userRegisterService;
     }
 
     @Override
@@ -34,7 +34,7 @@ public class OAuthUserService extends DefaultOAuth2UserService {
 
     private void registerOrUpdateUser(UserPrincipal principal, OAuthProvider provider) {
         var command = new OAuthRegisterCommand(principal.getName(), provider);
-        var userId = userService.getOrRegisterUser(command);
+        var userId = userRegisterService.getOrRegisterUser(command);
         principal.setUserId(userId);
     }
 }

--- a/src/main/java/com/depromeet/archive/util/SecurityUtils.java
+++ b/src/main/java/com/depromeet/archive/util/SecurityUtils.java
@@ -1,12 +1,16 @@
 package com.depromeet.archive.util;
 
 import com.depromeet.archive.domain.user.info.UserInfo;
-import com.depromeet.archive.exception.security.InvalidTokenException;
 import com.depromeet.archive.security.token.jwt.JwtAuthenticationToken;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.security.SecureRandom;
+
 public class SecurityUtils {
+
+    private static final String NUMBER_ALPHABET_STR = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     private SecurityUtils() {
     }
@@ -19,4 +23,13 @@ public class SecurityUtils {
             throw new AccessDeniedException("유저 인증 정보가 존재하지 않습니다");
         }
     }
+
+    public static String generateRandomString(int len) {
+        var sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            sb.append(NUMBER_ALPHABET_STR.charAt(RANDOM.nextInt(NUMBER_ALPHABET_STR.length())));
+        }
+        return sb.toString();
+    }
+
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,6 +35,18 @@ spring:
     properties:
       hibernate:
         format_sql: false
+  mail:
+    host: ${MAIL_HOST}
+    port: 587
+    username: ${MAIL_EMAIL}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
 
 jwt:
   secret-key: testKey

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -47,6 +47,11 @@ spring:
           starttls:
             enable: true
             required: true
+    executor:
+      core_pool_size: 2
+      max_pool_size: 2
+      queue_capacity: 5
+      await_termination_seconds: 120
 
 jwt:
   secret-key: testKey

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -38,6 +38,18 @@ spring:
       hibernate:
         format_sql: true
     open-in-view: false
+  mail:
+    host: ${MAIL_HOST}
+    port: 587
+    username: ${MAIL_EMAIL}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
 
 jwt:
   secret-key: testKey

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -50,6 +50,11 @@ spring:
           starttls:
             enable: true
             required: true
+    executor:
+      core_pool_size: 2
+      max_pool_size: 2
+      queue_capacity: 5
+      await_termination_seconds: 120
 
 jwt:
   secret-key: testKey

--- a/src/main/resources/application-prd.yml
+++ b/src/main/resources/application-prd.yml
@@ -43,6 +43,11 @@ spring:
           starttls:
             enable: true
             required: true
+    executor:
+      core_pool_size: 3
+      max_pool_size: 8
+      queue_capacity: 15
+      await_termination_seconds: 120
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}

--- a/src/main/resources/application-prd.yml
+++ b/src/main/resources/application-prd.yml
@@ -31,6 +31,18 @@ spring:
     properties:
       hibernate:
         format_sql: false
+  mail:
+    host: ${MAIL_HOST}
+    port: 587
+    username: ${MAIL_EMAIL}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}

--- a/src/main/resources/templates/temporary-password-mail-template.html
+++ b/src/main/resources/templates/temporary-password-mail-template.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+    <title>Archive Password Reset Mail</title>
+    <meta name="description" content="Archive Password Reset Mail">
+    <style type="text/css">
+        a:hover {
+            text-decoration: underline !important;
+        }
+    </style>
+</head>
+
+<body marginheight="0" topmargin="0" marginwidth="0" style="margin: 0px; background-color: #f2f3f8;" leftmargin="0">
+<!--100% body table-->
+<table cellspacing="0" border="0" cellpadding="0" width="100%" bgcolor="#f2f3f8"
+       style="@import url(https://fonts.googleapis.com/css?family=Rubik:300,400,500,700|Open+Sans:300,400,600,700); font-family: 'Open Sans', sans-serif;">
+    <tr>
+        <td>
+            <table style="background-color: #f2f3f8; max-width:670px;  margin:0 auto;" width="100%" border="0"
+                   align="center" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td style="height:80px;">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td style="text-align:center;">
+                        <img width="60"
+                             src="https://user-images.githubusercontent.com/37873745/162957919-3750eead-e16f-4630-8029-b0a7ff15d9e6.png"
+                             alt="archive-image-logo">
+                    </td>
+                </tr>
+                <tr>
+                    <td style="height:20px;">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td>
+                        <table width="95%" border="0" align="center" cellpadding="0" cellspacing="0"
+                               style="max-width:670px;background:#fff; border-radius:3px; text-align:center;-webkit-box-shadow:0 6px 18px 0 rgba(0,0,0,.06);-moz-box-shadow:0 6px 18px 0 rgba(0,0,0,.06);box-shadow:0 6px 18px 0 rgba(0,0,0,.06);">
+                            <tr>
+                                <td style="height:40px;">&nbsp;</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:0 35px;">
+                                    <h1 style="color:#1e1e2d; font-weight:500; margin:0;font-size:32px;font-family:'Rubik',sans-serif;">
+                                        Archive 임시 비밀번호 발급</h1>
+                                    <span
+                                            style="display:inline-block; vertical-align:middle; margin:29px 0 26px; border-bottom:1px solid #cecece; width:100px;"></span>
+                                    <div style="color:#455056; font-size:15px;line-height:24px; margin:0;">
+                                        <p>안녕하세요. <b>Archive</b> 입니다.</p>
+                                        <p>해당 비밀번호는 1회성으로 발급되며,</p>
+                                        <p>발급된 임시 비밀번호로 Archive 앱에서 비밀번호를 재설정 해주시길 바랍니다.</p>
+                                    </div>
+                                    <div style="background:#000000;text-decoration:none !important; font-weight:500; margin-top:35px; color:#fff;font-size:14px;padding:10px 24px;display:inline-block;border-radius:50px;"
+                                         th:text="${password}">Reset Password
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="height:40px;">&nbsp;</td>
+                            </tr>
+                        </table>
+                    </td>
+                <tr>
+                    <td style="height:20px;">&nbsp;</td>
+                </tr>
+                <tr>
+                    <table class="social_block" role="presentation"
+                           style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;" width="100%">
+                        <tbody>
+                        <tr>
+                            <td>
+                                <table align="center" border="0" cellpadding="0" cellspacing="0" class="social-table"
+                                       role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+                                       width="108px">
+                                    <tbody>
+                                    <tr>
+                                        <td style="padding:0 10px 0 10px;"><a href="mailto:archive.ticket@gmail.com"
+                                                                              target="_blank"><img alt="Mail"
+                                                                                                   height="32"
+                                                                                                   src="https://user-images.githubusercontent.com/37873745/162962656-520a14f1-61fd-4a43-b655-02de86e72ed5.png"
+                                                                                                   style="display: block; height: auto; border: 0;"
+                                                                                                   title="mail"
+                                                                                                   width="24"></a></td>
+                                        <td style="padding:0 10px 0 10px;"><a href="https://www.instagram.com/archive.ticket/"
+                                                                            target="_blank"><img alt="Instagram"
+                                                                                                 height="32"
+                                                                                                 src="https://user-images.githubusercontent.com/37873745/162962649-d1482a3b-0d37-4013-a3d0-283b95d4280f.png"
+                                                                                                 style="display: block; height: auto; border: 0;"
+                                                                                                 title="instagram"
+                                                                                                 width="20"></a></td>
+                                        <td style="padding:0 10px 0 10px;"><a href="https://apps.apple.com/kr/app/archive/id1599941822"
+                                                                            target="_blank"><img alt="App store"
+                                                                                                 height="32"
+                                                                                                 src="https://user-images.githubusercontent.com/37873745/162962632-65e08984-47e8-4905-bef1-4de2408ff430.png"
+                                                                                                 style="display: block; height: auto; border: 0;"
+                                                                                                 title="app store"
+                                                                                                 width="20"></a></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+
+                </tr>
+                <tr>
+                    <td style="text-align:center;">
+                        <p style="font-size:14px; color:rgba(69, 80, 86, 0.7411764705882353); line-height:18px; margin:0 0 0;">
+                            &copy; <strong>Archive</strong></p>
+                    </td>
+                    <td style="height:80px;">&nbsp;</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+<!--/100% body table-->
+</body>
+
+</html>


### PR DESCRIPTION
password 분실 시, 이메일을 통해 임시 비밀번호를 발급받을 수 있는 기능 추가

- 이메일/비밀번호 유저만 가능
- 임의 문자열(10자리 - 알파벳/숫자 랜덤) 만들어서 임시 비밀번호로 설정
- 메일 전송

![image](https://user-images.githubusercontent.com/37873745/162974173-3a36b4a8-25eb-4275-b9b3-cafeb6f86937.png)


---

실수로 부가적인 기능을 해당 PR에 포함시켰음.
- Slack register notification template 변경
  - 개발환경과 회원가입 타입(`oauth - provider`, `Id/password`)이 출력되도록 수정